### PR TITLE
Fix national plotting

### DIFF
--- a/R/plotting.R
+++ b/R/plotting.R
@@ -173,7 +173,6 @@ plot_nation_forecasters <- function(predictions_cards, exclude_geos = c(), start
     "*",
     epirange(start_day, 20300101)
   ) %>%
-    filter(!geo_value %in% exclude_geos) %>%
     mutate(
       value = 7L * .data$value,
       data_source = "hhs"

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -185,20 +185,15 @@ plot_nation_forecasters <- function(predictions_cards, exclude_geos = c(), start
   td2 <- epidatr::pub_covidcast(
     "chng",
     "smoothed_adj_outpatient_flu",
-    "state",
+    "nation",
     "day",
     "*",
     epirange(start_day, 20300101)
   ) %>%
-    filter(!geo_value %in% exclude_geos) %>%
-    rename(target_end_date = time_value) %>%
-    mutate(
-      data_source = "chng"
-    ) %>%
-    group_by(
-      target_end_date
-    ) %>%
-    summarize(value = sum(value))
+    select(
+      target_end_date = time_value,
+      value
+    )
   td1.max <- td1 %>%
     summarize(max_value = max(value)) %>%
     pull(max_value)


### PR DESCRIPTION
- Fix recent-hhs-data part of the national plot when we have excluded geos: we should still sum over all geos / according to the guidelines for how to define national data (... the guidelines might actually say to exclude some territories, but this probably won't have a big effect on national plotting).
- Fix recent-chng-data part of the national plot: since chng is a percent-of-visits signal rather than a count signal, summing across states is inappropriate.  Just use the specially-prepared `geo_type = "nation"` signal.